### PR TITLE
Add 7 and 14 day rolling averages

### DIFF
--- a/src/RegionSelect.js
+++ b/src/RegionSelect.js
@@ -333,12 +333,16 @@ class RegionSelect extends ReactQueryParams {
       );
     }
 
-    const graphOptionsWidth = 140;
+    const graphOptionsWidth = 250;
     const graphOptions = [
       <Option value="confirm">Confirmed Cases</Option>,
       <Option value="dead">Deaths</Option>,
       <Option value="confirmNew">New Cases</Option>,
       <Option value="deadNew">New Deaths</Option>,
+      <Option value="confirm7Day">New Cases (7 day rolling average)</Option>,
+      <Option value="dead7Day">New Deaths (7 day rolling average)</Option>,
+      <Option value="confirm14Day">New Cases (14 day rolling average)</Option>,
+      <Option value="dead14Day">New Deaths (14 day rolling average)</Option>,
     ];
 
     const commonGraphData = {

--- a/src/dataLib.js
+++ b/src/dataLib.js
@@ -55,6 +55,25 @@ const newCasesMaps = {
   deadNew: 'dead',
 };
 
+const rollingAveragesMaps = {
+  confirm7Day: {
+    sourceField: "confirm",
+    numDays: 7,
+  },
+  dead7Day: {
+    sourceField: "dead",
+    numDays: 7,
+  },
+  confirm14Day: {
+    sourceField: "confirm",
+    numDays: 14,
+  },
+  dead14Day: {
+    sourceField: "dead",
+    numDays: 14,
+  },
+}
+
 export function ensureDataHasFieldName(data, fieldName) {
   if (fieldName in newCasesMaps) {
     const sourceField = newCasesMaps[fieldName];
@@ -63,6 +82,19 @@ export function ensureDataHasFieldName(data, fieldName) {
     data.forEach((row) => {
       row[fieldName] = row[sourceField] - lastValue;
       lastValue = row[sourceField];
+    });
+  } else if (fieldName in rollingAveragesMaps) {
+    const rollingAverageMetdata = rollingAveragesMaps[fieldName];
+    const sourceField = rollingAverageMetdata.sourceField;
+    const numDays = rollingAverageMetdata.numDays;
+
+    let previousValues = [];
+    let lastValue = 0;
+    data.forEach((row) => {
+      previousValues.push(row[sourceField] - lastValue);
+      lastValue = row[sourceField];
+      const lastWeek = previousValues.slice(-1 * numDays);
+      row[fieldName] = lastWeek.reduce((x, y) => x + y) / numDays;
     });
   }
 


### PR DESCRIPTION
These more accurately detect the rates of change, especially when reporting is delayed on certain days. In particular, I imagine the 14 days averages are important since that's the commonly believed lag time for the virus incubation

----

Note, if you want, we can replace newCaseMaps with values in rollingAveragesMaps that have 1 day rolling averages to reduce some of the code duplication. I figured I'd let you decide how you want that all to look