### PR TITLE
Round graph data to 1 decimal place

### DIFF
--- a/src/dataLib.js
+++ b/src/dataLib.js
@@ -37,7 +37,9 @@ export function formatNumber(n) {
   if (n === undefined) {
     return n;
   }
-  return n.toLocaleString();
+  // round to one decimal place
+  const truncated = Math.round(n * 10) / 10;
+  return truncated.toLocaleString();
 }
 
 export function categoryColorNameMapping(internalCatName) {


### PR DESCRIPTION
I could have used `n.toLocaleString(undefined, {maximumFractionDigits: 1})`, where the `undefined` is passed for the `locales` parameter (which we want to stay as the user locale). I felt the `undefined` was a little awkward, and the math is simple enough, but if you feel otherwise I can change it.

Before:
<img width="513" alt="Screen Shot 2020-04-02 at 15 27 44" src="https://user-images.githubusercontent.com/792797/78249189-9c395000-74f6-11ea-9a73-2875f1deac44.png">

After:
<img width="508" alt="Screen Shot 2020-04-02 at 15 13 20" src="https://user-images.githubusercontent.com/792797/78249198-a1969a80-74f6-11ea-9cea-bb915edde13c.png">
