### PR TITLE
Fix the update dataset workflow

### DIFF
--- a/.github/workflows/update-datasets.yml
+++ b/.github/workflows/update-datasets.yml
@@ -35,6 +35,7 @@ jobs:
           git commit -m "Updating datasets" -a || echo "No dataset updates"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@3a0787a996eb8719f2f4b45c33814870829a1b44
         with:
           github_token: ${{ secrets.COVID_BOT_GITHUB_TOKEN }}
+          branch: master


### PR DESCRIPTION
It was broken by https://github.com/ad-m/github-push-action/commit/b7582201c80f5e62d3be40f7e3b57acf299ea9b8, which began pushing to the `main` branch instead of the previous default of `master`

I've also gone ahead and pinned the version of the action to a specific commit so that updates to the action won't break us / cause any unexpected changes in behavior.